### PR TITLE
Funding Values now in Child Projects

### DIFF
--- a/src/platform/modules/common/src/main/scala/uk/gov/dfid/common/MongoProcessAudit.scala
+++ b/src/platform/modules/common/src/main/scala/uk/gov/dfid/common/MongoProcessAudit.scala
@@ -32,6 +32,10 @@ class DataLoadAuditor @Inject()(db: DefaultDB) extends Auditor {
   def warn(msg: String)    = insert("warn", msg)
 
   private def insert(msgType: String, msg: String) = {
+
+    // we println here
+    println(s"$msgType: $msg")
+
     audits.insert(
       BSONDocument(
         "type"    -> BSONString(msgType),

--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Aggregator.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Aggregator.scala
@@ -205,8 +205,6 @@ class Aggregator(engine: ExecutionEngine, db: DefaultDB, projects: Api[Project],
       )
     }
 
-    auditor.info("Summing up Project Budget spend")
-
     engine.execute(
       s"""
         | START  txn = node:entities(type="transaction")

--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Loader.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Loader.scala
@@ -24,7 +24,8 @@ class Loader @Inject()(manager: GraphDatabaseManager, mongodb: DefaultDB, audito
 
   def load = {
     future {
-      val neo4j      = manager.restart(true)
+      // val neo4j      = manager.restart(true)
+      val neo4j      = manager.get
       val sources    = mongodb.collection("iati-datasources")
       val engine     = new ExecutionEngine(neo4j)
       val aggregator = new Aggregator(engine, mongodb, new ProjectsApi(mongodb), auditor)
@@ -33,7 +34,7 @@ class Loader @Inject()(manager: GraphDatabaseManager, mongodb: DefaultDB, audito
 
       auditor.info("Loading data")
 
-      validateAndMap(sources, neo4j)
+      //validateAndMap(sources, neo4j)
       aggregator.rollupCountryBudgets
       aggregator.rollupCountrySectorBreakdown
       aggregator.rollupCountryProjectBudgets

--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/ProjectAggregator.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/ProjectAggregator.scala
@@ -159,7 +159,7 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
           | WHERE  n.hierarchy = 2
           | AND    o.ref = "GB-1"
           | AND	   a.type = 1
-          | RETURN a.ref as id, a.`related-activity` as title, s.code as code, s.sector as name, 
+          | RETURN a.ref as id, a.`related-activity` as title, s.code as code, s.sector as name,
           |        COALESCE(s.percentage?, 100) as percentage, sum(v.value) as val,
           |        (COALESCE(s.percentage?, 100) / 100.0 * sum(v.value)) as total
           | ORDER BY id asc, total desc
@@ -172,7 +172,7 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
         }
         val name        = row("name").asInstanceOf[String]
         val code        = row("code").asInstanceOf[Long]
-        val total       = row("total")  match {          
+        val total       = row("total")  match {
           case v: java.lang.Integer => v.toLong
           case v: java.lang.Long    => v.toLong
           case v: java.lang.Double  => v.toLong
@@ -193,7 +193,7 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
       case e: Throwable => println(e.getMessage); println(e.getStackTraceString)
     }
   }
-  
+
   def collectPartnerProjects = {
 
     auditor.info("Collecting Partner Projects")
@@ -239,6 +239,33 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
           | RETURN a.ref as id
         """.stripMargin).toSeq.head("id").asInstanceOf[String]
 
+      // now we need to sum up the project budgets and spend.  this is not specific
+      // to dfid itself
+      val (totalBudget, totalSpend) = engine.execute(
+        """
+          | START  funded=node:entities(type="iati-activity")
+          | MATCH  funded-[:budget]-budget-[:value]-budget_value,
+          |        funded-[:transaction]-transaction-[:value]-transaction_value,
+          |        transaction-[:`transaction-type`]-type
+          | WHERE  funded.`iati-identifier` = 'GB-CHC-1064413-GPAF-INN-001-DIFD2'
+          | AND    (type.`code` = 'D' OR type.`code` = 'E')
+          | RETURN SUM(budget_value.value) as totalBudget,
+          |        SUM(transaction_value.value) as totalSpend
+        """.stripMargin).toSeq.headOption.map { row =>
+        val totalBudget = row("totalBudget") match {
+          case v: java.lang.Integer => v.toLong
+          case v: java.lang.Long    => v.toLong
+        }
+
+        val totalSpend = row("totalSpend") match {
+          case v: java.lang.Integer => v.toLong
+          case v: java.lang.Long    => v.toLong
+        }
+
+        totalBudget -> totalSpend
+      }.getOrElse(0L -> 0L)
+
+
       db.collection("funded-projects").insert(
         BSONDocument(
           "funded"      -> BSONString(funded),
@@ -246,7 +273,9 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
           "title"       -> BSONString(title),
           "reporting"   -> BSONString(reporting),
           "description" -> BSONString(description),
-          "funds"       -> BSONLong(funds)
+          "funds"       -> BSONLong(funds),
+          "totalBudget" -> BSONLong(totalBudget),
+          "totalSpend"  -> BSONLong(totalSpend)
         )
       )
     }

--- a/src/platform/site/config.rb
+++ b/src/platform/site/config.rb
@@ -151,10 +151,12 @@ end
 
   # format the project model to suit the project templates
   project = {
-    'iatiId'      => funded_project['funded'],
-    'title'       => funded_project['title'],
-    'description' => funded_project['description'],
-    'funds'       => funded_project['funds']
+    'iatiId'            => funded_project['funded'],
+    'title'             => funded_project['title'],
+    'description'       => funded_project['description'],
+    'funds'             => funded_project['funds'],
+    'totalBudget'       => funded_project['totalBudget'],    
+    'totalProjectSpend' => funded_project['totalSpend']
   }
 
   # get the other funded projects


### PR DESCRIPTION
This pull request adds both the `totalBudget` and `totalSpend` to the child/funded projects collection for displaying on the main page.
