### PR TITLE
Contact_Us_Changes

### DIFF
--- a/src/platform/site/source/404.html.erb
+++ b/src/platform/site/source/404.html.erb
@@ -5,8 +5,8 @@ title: Development Tracker
 
 <div id="page-title" class="row">
     <div class="twelve columns">
-        <img src="/images/ukaid_logo.gif" alt="UK aid from the British people">
-    </div>
+       <img src="/images/ukaid_logo.png" alt="UK aid from the British people">
+   </div>
 </div>
 
 <div class="row">

--- a/src/platform/site/source/feedback/index.html.erb
+++ b/src/platform/site/source/feedback/index.html.erb
@@ -61,7 +61,7 @@ title: Development Tracker
                       <label for="description" class="inline">Description</label>
                     </div>
                     <div class="eight mobile-three columns">
-                      <textarea id="description" name="description" class="eight"></textarea>
+                      <textarea id="description" name="description" class="eight" rows="10"></textarea>
                     </div>
                   </div>
                    <div class="row">

--- a/src/platform/site/source/fraud/index.html.erb
+++ b/src/platform/site/source/fraud/index.html.erb
@@ -54,7 +54,7 @@ title: Development Tracker
                       <label for="description" class="inline">Description of concern</label>
                     </div>
                     <div class="eight mobile-three columns">
-                      <textarea id="description" name="description" class="eight"></textarea>
+                      <textarea id="description" name="description" class="eight" rows="10"></textarea>
                     </div>
                   </div>
                   

--- a/src/platform/site/source/layouts/landing.erb
+++ b/src/platform/site/source/layouts/landing.erb
@@ -69,6 +69,7 @@
               <li><a href="/faq">What does this mean?</a></li>
               <li><a href="/feedback">Provide feedback</a></li>
               <li><a href="/cookies">Cookies</a></li>
+              <li><a href="https://www.gov.uk/government/organisations/department-for-international-development#contact_4">Contact Us</a></li>
             </ul>
           </nav>
           <div class="row">

--- a/src/platform/site/source/layouts/layout.erb
+++ b/src/platform/site/source/layouts/layout.erb
@@ -72,6 +72,7 @@
               <li><a href="/faq">What does this mean?</a></li>
               <li><a href="/feedback">Provide feedback</a></li>
               <li><a href="/cookies">Cookies</a></li>
+              <li><a href="https://www.gov.uk/government/organisations/department-for-international-development#contact_4">Contact Us</a></li>
             </ul>
           </nav>
           <div class="row">


### PR DESCRIPTION
Add a 'Contact Us' link to the footer of the template pages
Fix the issue where the UK Aid image is missing from 404 page
Increase size of text area boxes on the Fraud and Feedback pages 
