### PR TITLE
Fixed checkboxes disappearing on refreshing organisation and activity XML files

### DIFF
--- a/src/platform/modules/admin/app/controllers/traits/IatiDataSourceActions.scala
+++ b/src/platform/modules/admin/app/controllers/traits/IatiDataSourceActions.scala
@@ -34,10 +34,18 @@ trait IatiDataSourceActions { this : Controller with Secured =>
   def refresh = SecuredAction { user => request =>
     Async {
       sources.load(sourceType).map { _ =>
-        Redirect(routes.OrganisationSources.index).flashing(
-          "message" -> s"${sourceType.capitalize} Sources refreshed",
-          "type"    -> "info"
-        )
+        if(sourceType == "organisation") {
+          Redirect(routes.OrganisationSources.index).flashing(
+            "message" -> s"${sourceType.capitalize} Sources refreshed",
+            "type"    -> "info"
+          )
+        }
+        else {
+          Redirect(routes.ActivitySources.index).flashing(
+            "message" -> s"${sourceType.capitalize} Sources refreshed",
+            "type"    -> "info"
+          )
+        }
       }
     }
   }

--- a/src/platform/modules/admin/app/lib/IatiDataSourceSelector.scala
+++ b/src/platform/modules/admin/app/lib/IatiDataSourceSelector.scala
@@ -102,7 +102,7 @@ class IatiDataSourceSelector @Inject()(database: DefaultDB) extends SourceSelect
             if(downloadUrl.isEmpty) {
               None
             } else {
-              Some(IatiDataSource(None, sourceType, title, downloadUrl.get, list.contains(url)))
+              Some(IatiDataSource(None, sourceType, title, downloadUrl.get, list.contains(downloadUrl.get)))
             }
           }
 


### PR DESCRIPTION
Two key changes:
- fixed issue with checkboxes disappearing when the activity or organisation XML sources were refreshed
- fixed minor issue with redirect to organisation sources when activity sources were refreshed - just plain confusin'
