### PR TITLE
Moved country results loading to regular Load IATI Data process

### DIFF
--- a/src/platform/modules/loader/src/main/resources/country_results.csv
+++ b/src/platform/modules/loader/src/main/resources/country_results.csv
@@ -1,0 +1,167 @@
+Country,Code,Pillar,Results Indicators,,Total,,Thousands
+Afghanistan,AF,Education,Number of children completing primary education supported by DFID (per annum),,17000,,17
+Afghanistan,AF,Education,Number of children supported by DFID in lower secondary education (per annum),,39000,,39
+Afghanistan,AF,Education,Number of children supported by DFID in primary education (per annum),,141000,,141
+Afghanistan,AF,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,1400000,,1400
+Africa regional ,298,Climate Change,Number of people supported by DFID funding to cope with the effects of climate change,,7000,,7
+Africa regional ,298,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,5000,,5
+Africa regional ,298,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,1062000,,1062
+Bangladesh,BD,Climate Change,Number of people supported by DFID funding to cope with the effects of climate change,,475000,,475
+Bangladesh,BD,Education,"Number of births delivered with the help of nurses, midwives or doctors through DFID support",,104000,,104
+Bangladesh,BD,Education,Number of children supported by DFID in primary education (per annum),,357000,,357
+Bangladesh,BD,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,356000,,356
+Bangladesh,BD,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,150000,,150
+Bangladesh,BD,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,234000,,234
+Bangladesh,BD,"Reproductive, maternal and neo-natal health",Number of additional women using modern methods of family planning through DFID support,,57000,,57
+Bangladesh,BD,"Reproductive, maternal and neo-natal health",Number of people with sustainable access to clean drinking water sources through DFID support,,293000,,293
+Bangladesh,BD,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,4800000,,4800
+Bangladesh,BD,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,1131000,,1131
+Bangladesh,BD,Wealth Creation,Number of people with access to financial services as a result of DFID support,,355000,,355
+Burma,MM,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,172000,,172
+Burma,MM,Wealth Creation,Number of people benefitting from DFID-supported cash transfer programmes,,12000,,12
+Burundi,BI,Education,Number of children completing primary education supported by DFID (per annum),,58000,,58
+Burundi,BI,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,168000,,168
+Burundi,BI,Governance and Security,Number of women and girls with improved access to security and justice services through DFID support,,1000,,1
+Caribbean,,Climate Change,Number of people supported by DFID funding to cope with the effects of climate change,,25000,,25
+Central Asia,619,Wealth Creation,Number of children supported by DFID in primary education (per annum),,4000,,4
+DRC,CD,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,924000,,924
+DRC,CD,Governance and Security,Number of people who vote in elections supported by DFID,,18900000,,18900
+DRC,CD,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,929000,,929
+DRC,CD,"Poverty, Vulnerability, Nutrition and Hunger",Number of children under five and pregnant women reached through DFID's nutrition-relevant programmes,,153000,,153
+DRC,CD,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,94000,,94
+DRC,CD,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,185000,,185
+DRC,CD,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,199000,,199
+DRC,CD,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,274000,,274
+Ethiopia,ET,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,3441000,,3441
+Ethiopia,ET,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,1895000,,1895
+Ethiopia,ET,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,754000,,754
+Ethiopia,ET,"Poverty, Vulnerability, Nutrition and Hunger",Number of people achieving food security through DFID support,,283000,,283
+Ethiopia,ET,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,1240000,,1240
+Ethiopia,ET,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,86000,,86
+Ghana,GH,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,7000,,7
+Ghana,GH,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,2350000,,2350
+India,IN,Climate Change,Number of people supported by DFID funding to cope with the effects of climate change,,2009000,,2009
+India,IN,Climate Change,Number of people with improved access to clean energy as a result of DFID funding,,644000,,644
+India,IN,Education,Number of people with sustainable access to clean drinking water sources through DFID support,,835000,,835
+India,IN,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,1475000,,1475
+India,IN,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,122000,,122
+India,IN,"Poverty, Vulnerability, Nutrition and Hunger",Number of children under five and pregnant women reached through DFID's nutrition-relevant programmes,,1842000,,1842
+India,IN,"Reproductive, maternal and neo-natal health",Number of additional women using modern methods of family planning through DFID support,,112000,,112
+India,IN,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,115000,,115
+India,IN,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,114000,,114
+India,IN,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,114000,,114
+India,IN,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,595000,,595
+India,IN,Wealth Creation,Number of people supported to have choice and control over their development and to hold decision makers to account,,124000,,124
+Kenya,KE,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,206000,,206
+Kenya,KE,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,2125000,,2125
+Kenya,KE,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,594000,,594
+Kenya,KE,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,3000,,3
+Kenya,KE,Wealth Creation,Number of children completing primary education supported by DFID (per annum),,586000,,586
+Malawi,MW,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,6000,,6
+Malawi,MW,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,85000,,85
+Malawi,MW,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,50000,,50
+Malawi,MW,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,50000,,50
+Malawi,MW,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,50000,,50
+MENAD regional,,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,10000,,10
+MENAD regional,,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,194000,,194
+MENAD regional,,Wealth Creation,"Number of births delivered with the help of nurses, midwives or doctors through DFID support",,13000,,13
+Mozambique,MZ,Education,Number of children completing primary education supported by DFID (per annum),,16000,,16
+Mozambique,MZ,Education,Number of children supported by DFID in lower secondary education (per annum),,28000,,28
+Mozambique,MZ,Education,Number of people with access to improved hygiene through DFID support to hygiene promotion,,258000,,258
+Mozambique,MZ,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,13000,,13
+Mozambique,MZ,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,2270000,,2270
+Mozambique,MZ,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,64000,,64
+Mozambique,MZ,"Reproductive, maternal and neo-natal health",Number of additional women using modern methods of family planning through DFID support,,56000,,56
+Mozambique,MZ,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,35000,,35
+Mozambique,MZ,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,30000,,30
+Mozambique,MZ,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,50000,,50
+Mozambique,MZ,Wealth Creation,Number of people supported by DFID funding to cope with the effects of climate change,,89000,,89
+Nepal,NP,Climate Change,Number of hectares where deforestation and degradation have been avoided,,3000,,3
+Nepal,NP,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,80000,,80
+Nepal,NP,Governance and Security,Number of women and girls with improved access to security and justice services through DFID support,,7000,,7
+Nepal,NP,"Poverty, Vulnerability, Nutrition and Hunger",Number of children under five and pregnant women reached through DFID's nutrition-relevant programmes,,214000,,214
+Nepal,NP,"Reproductive, maternal and neo-natal health",Number of additional women using modern methods of family planning through DFID support,,12000,,12
+Nepal,NP,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,13000,,13
+Nepal,NP,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,25000,,25
+Nepal,NP,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,30000,,30
+Nepal,NP,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,59000,,59
+Nepal,NP,Wealth Creation,Number of people supported through DFID programmes to improve their rights to land and property,,200000,,200
+Nigeria,NG,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,45000,,45
+Nigeria,NG,Governance and Security,Number of people who vote in elections supported by DFID,,40000000,,40000
+Nigeria,NG,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,500000,,500
+Nigeria,NG,"Poverty, Vulnerability, Nutrition and Hunger",Number of children under five and pregnant women reached through DFID's nutrition-relevant programmes,,321000,,321
+Nigeria,NG,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,14000,,14
+Nigeria,NG,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,497000,,497
+OPTs,PS,Education,Number of children completing primary education supported by DFID (per annum),,5000,,5
+OPTs,PS,Education,Number of children supported by DFID in lower secondary education (per annum),,2000,,2
+OPTs,PS,Education,Number of people reached with emergency food assistance through DFID support,,43000,,43
+OPTs,PS,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,201000,,201
+OPTs,PS,Wealth Creation,Number of people supported through DFID programmes to improve their rights to land and property,,2000,,2
+Pakistan,PK,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,440000,,440
+Pakistan,PK,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,858000,,858
+Pakistan,PK,Wealth Creation,Number of additional women using modern methods of family planning through DFID support,,103000,,103
+Rwanda,RW,Education,Number of children completing primary education supported by DFID (per annum),,18000,,18
+Rwanda,RW,Education,Number of children supported by DFID in lower secondary education (per annum),,51000,,51
+Rwanda,RW,Education,Number of people supported by DFID funding to cope with the effects of climate change,,246000,,246
+Rwanda,RW,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,819000,,819
+Rwanda,RW,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,34000,,34
+Rwanda,RW,Wealth Creation,Number of people supported through DFID programmes to improve their rights to land and property,,401000,,401
+Sierra Leone ,SL,Education,Number of children completing primary education supported by DFID (per annum),,11000,,11
+Sierra Leone ,SL,Education,Number of children supported by DFID in lower secondary education (per annum),,26000,,26
+Sierra Leone ,SL,Education,Number of children supported by DFID in primary education (per annum),,106000,,106
+Sierra Leone ,SL,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,30000,,30
+Sierra Leone ,SL,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,913000,,913
+Sierra Leone ,SL,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,513000,,513
+Sierra Leone ,SL,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,262000,,262
+Somalia,SO,Governance and Security,Number of women and girls with improved access to security and justice services through DFID support,,1000,,1
+Somalia,SO,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,310000,,310
+Somalia,SO,"Poverty, Vulnerability, Nutrition and Hunger",Number of children under five and pregnant women reached through DFID's nutrition-relevant programmes,,148000,,148
+South Sudan,SS,Education,Number of children supported by DFID in primary education (per annum),,12000,,12
+South Sudan,SS,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,8000,,8
+South Sudan,SS,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,1000,,1
+South Sudan,SS,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,23000,,23
+South Sudan,SS,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,9000,,9
+South Sudan,SS,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,41000,,41
+Sudan,SD,Governance and Security,Number of women and girls with improved access to security and justice services through DFID support,,273000,,273
+Sudan,SD,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,17000,,17
+Sudan,SD,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,41000,,41
+Tanzania,TZ,Education,Number of children completing primary education supported by DFID (per annum),,48000,,48
+Tanzania,TZ,Education,Number of children supported by DFID in lower secondary education (per annum),,69000,,69
+Tanzania,TZ,Education,Number of children supported by DFID in primary education (per annum),,388000,,388
+Tanzania,TZ,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,4145000,,4145
+Tanzania,TZ,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,101000,,101
+Tanzania,TZ,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,726000,,726
+Tanzania,TZ,Wealth Creation,Number of people with sustainable access to an improved sanitation facility through DFID support,,117000,,117
+Uganda,UG,Education,Number of children completing primary education supported by DFID (per annum),,1000,,1
+Uganda,UG,Education,Number of children supported by DFID in lower secondary education (per annum),,1000,,1
+Uganda,UG,Education,Number of children supported by DFID in primary education (per annum),,8000,,8
+Uganda,UG,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,4751000,,4751
+Uganda,UG,Governance and Security,Number of women and girls with improved access to security and justice services through DFID support,,3000,,3
+Uganda,UG,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,13000,,13
+Uganda,UG,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,17000,,17
+Uganda,UG,"Reproductive, maternal and neo-natal health",Number of additional women using modern methods of family planning through DFID support,,132000,,132
+Uganda,UG,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,17000,,17
+Uganda,UG,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,3000,,3
+Vietnam,VN,Education,Number of children completing primary education supported by DFID (per annum),,25000,,25
+Vietnam,VN,Education,Number of children supported by DFID in primary education (per annum),,304000,,304
+Vietnam,VN,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,93000,,93
+Vietnam,VN,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,71000,,71
+Yemen,YE,Governance and Security,Number of people who vote in elections supported by DFID,,6661000,,6661
+Yemen,YE,Humanitarian and Emergency Response,Number of people reached with emergency food assistance through DFID support,,252000,,252
+Yemen,YE,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,84000,,84
+Yemen,YE,Water and Sanitation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,30000,,30
+Yemen,YE,Water and Sanitation,Number of people with sustainable access to an improved sanitation facility through DFID support,,1000,,1
+Yemen,YE,Water and Sanitation,Number of people with sustainable access to clean drinking water sources through DFID support,,46000,,46
+Yemen,YE,Wealth Creation,Number of people with access to improved hygiene through DFID support to hygiene promotion,,3000,,3
+Zambia,ZM,Education,Number of children supported by DFID in lower secondary education (per annum),,9000,,9
+Zambia,ZM,Education,Number of children supported by DFID in primary education (per annum),,57000,,57
+Zambia,ZM,Governance and Security,Number of people supported to have choice and control over their development and to hold decision makers to account,,6000,,6
+Zambia,ZM,Governance and Security,Number of people who vote in elections supported by DFID,,2750000,,2750
+Zambia,ZM,Malaria,Number of insecticide treated bed-nets distributed with DFID support,,1000000,,1000
+Zambia,ZM,"Poverty, Vulnerability, Nutrition and Hunger",Number of children under five and pregnant women reached through DFID's nutrition-relevant programmes,,22000,,22
+Zambia,ZM,"Poverty, Vulnerability, Nutrition and Hunger",Number of people benefitting from DFID-supported cash transfer programmes,,96000,,96
+Zambia,ZM,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,4000,,4
+Zimbabwe,ZW,Education,Number of children completing primary education supported by DFID (per annum),,10000,,10
+Zimbabwe,ZW,Education,Number of children supported by DFID in lower secondary education (per annum),,6000,,6
+Zimbabwe,ZW,Education,Number of children supported by DFID in primary education (per annum),,86000,,86
+Zimbabwe,ZW,"Reproductive, maternal and neo-natal health","Number of births delivered with the help of nurses, midwives or doctors through DFID support",,26000,,26

--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/CountryResults.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/CountryResults.scala
@@ -1,0 +1,68 @@
+package uk.gov.dfid.loader
+
+import org.neo4j.cypher.ExecutionEngine
+import reactivemongo.api.DefaultDB
+import uk.gov.dfid.common.{Auditor, DataLoadAuditor}
+import reactivemongo.bson.{BSONArray, BSONString, BSONDocument}
+import reactivemongo.bson.handlers.DefaultBSONHandlers._
+import concurrent.ExecutionContext.Implicits.global
+import concurrent.Await
+import concurrent.duration.Duration
+import io.Source
+import scala.util.parsing.combinator.RegexParsers
+
+class CountryResults(engine: ExecutionEngine, db: DefaultDB, auditor: Auditor) {
+
+  def loadCountryResults = {
+    val country_results = db.collection("country-results")
+    val country_results_src = Source.fromURL(getClass.getResource("/country_results.csv"))
+    
+    Await.ready(country_results.drop(), Duration.Inf)
+
+    val source = country_results_src.getLines.drop(1).mkString("\n")
+    val results = CSV.parse(source)
+    results.foreach { result =>
+      val document = BSONDocument(
+        "country" -> BSONString(result(0)),
+        "code" -> BSONString(result(1)),
+        "pillar" -> BSONString(result(2)),
+        "results" -> BSONString(result(3)),
+        "total" -> BSONString(result(5))
+      )
+      //val label = BSONString(result(0))
+
+      Await.ready(country_results.insert(document), Duration.Inf)
+      //auditor.info(s"Inserted results for " + label.toString)
+    }
+  }
+
+  object CSV extends RegexParsers {
+    override val skipWhitespace = false   // meaningful spaces in CSV
+
+    def COMMA   = ","
+    def DQUOTE  = "\""
+    def DQUOTE2 = "\"\"" ^^ { case _ => "\"" }  // combine 2 dquotes into 1
+    def CRLF    = "\r\n" | "\n"
+    def TXT     = "[^\",\r\n]".r
+    def SPACES  = "[ \t]+".r
+
+    def file: Parser[List[List[String]]] = repsep(record, CRLF) <~ (CRLF?)
+
+    def record: Parser[List[String]] = repsep(field, COMMA)
+
+    def field: Parser[String] = escaped|nonescaped
+
+    def escaped: Parser[String] = {
+      ((SPACES?)~>DQUOTE~>((TXT|COMMA|CRLF|DQUOTE2)*)<~DQUOTE<~(SPACES?)) ^^ {
+        case ls => ls.mkString("")
+      }
+    }
+
+    def nonescaped: Parser[String] = (TXT*) ^^ { case ls => ls.mkString("") }
+
+    def parse(s: String) = parseAll(file, s) match {
+      case Success(res, _) => res
+      case e => throw new Exception(e.toString)
+    }
+  }
+}

--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Loader.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Loader.scala
@@ -34,11 +34,16 @@ class Loader @Inject()(manager: GraphDatabaseManager, mongodb: DefaultDB, audito
       val other      = new OtherOrgAggregator(engine, mongodb, auditor)
       val sectors    = new Sectors(mongodb)
       val indexer    = new Indexer(mongodb, engine, sectors)
+      val results    = new CountryResults(engine, mongodb, auditor)
 
       // drop current audtis table.  Transient data ftw
       auditor.drop
       auditor.info("Loading data")
 
+      auditor.info("Loading country results")
+      results.loadCountryResults
+      auditor.info("Finished loading country results")
+      
       validateAndMap(sources, neo4j)
       aggregator.rollupCountryBudgets
       aggregator.rollupCountrySectorBreakdown


### PR DESCRIPTION
Moved the country results loading process from the Migrator utility into the main Loader. This now loads the country results CSV file into Mongo at each data load.
