### PR TITLE
Remove beta references

### DIFF
--- a/src/platform/site/source/about/index.html.erb
+++ b/src/platform/site/source/about/index.html.erb
@@ -28,18 +28,18 @@ title: Development Tracker
 
 <p>The tracker is built using open data published by UK Government and partners, using the <a href="http://iatistandard.org">International Aid Transparency Initiative (IATI) standard</a>. The IATI standard is an international standard for international development data and allows ready comparison of information from different donors.</p>
 
-<p>Because the site uses data published to an open standard (IATI), we can also import and use data from other publishers. We are already using data provided by the Department of Energy and Climate Change (DECC), and will be incorporating data from other UK government bodies as they publish to IATI.</p>
+<p>Because the site uses data published to an open standard (IATI), we can also import and use data from other publishers. We are already using data provided by the Department of Energy and Climate Change (DECC), Home Office, Foreign and Commonwealth (FCO), and will be incorporating data from other UK government bodies as they publish their data to IATI.</p>
 
 <p>The site also incorporates data published by DFID's delivery partners, initially on a small-scale to prove the concept that aid can be traced through the aid delivery chain using open data. The <a href="/projects/GB-1-202035/">Global Poverty Action Fund</a> example shows data published by a number of partners, and really shows the promise of this approach. Our goal is to be able to use open data to trace the delivery of aid from donor to beneficiary, helping to maximise aid effectiveness.</p>
 
-<p>The site also shows mapping of international development projects at sub-national level, which has been carried out initially in <a href="/countries/BD/">Bangladesh</a>.</p>
+<p>The site also shows mapping of international development projects at sub-national level, which has been carried out initially in <a href="/countries/BD/">Bangladesh</a> and <a href="/countries/NP/">Nepal</a>.</p>
 
-<h3>API and open source</h3>
-<p>The site also contains a prototype version of an API (application programming interface) enabling developers to retrieve the data in JSON format. There are more features to develop for the API, so we welcome your feedback.</p>
+<h3>API and source code</h3>
+<p>The site also contains a prototype version of an API (application programming interface) enabling developers to retrieve the data in JSON format. We want to develop more features for the API, so we welcome your feedback.</p>
 
-<p>We will be making the source code for the Development Tracker available very soon, so that others can freely re-use or even contribute to the code. This may give other organisations a good starting point in visualising their own data, and encourage a community of innovative developers to build, share and re-use interesting visualisations built on the data.</p>
+<p>The source code for the Development Tracker is now available on <a href="https://github.com/DFID/aid-platform-beta">GitHub</a>, so that others can freely re-use or even contribute to the code. We want to give other organisations a good starting point in visualising their own data, and encourage a community of innovative developers to build, share and re-use interesting visualisations built on the data.</p>
 
 <h3>We welcome your feedback</h3>
-<p>We would very much welcome your <a href="/feedback">comments on this Beta</a> site and the future direction it should take.</p>
+<p>We would very much welcome your <a href="/feedback">comments on this site</a> and ideas for future development.</p>
   </div>
 </div>

--- a/src/platform/site/source/layouts/landing.erb
+++ b/src/platform/site/source/layouts/landing.erb
@@ -41,22 +41,12 @@
     <header role="banner" id="global-header">
       <div class="row">
         <div class="twelve columns">
-          <h2><a href="/" title="Go to the homepage">Development Tracker <span style="color: #F17921">Beta</span></a></h2>
+          <h2><a href="/" title="Go to the homepage">Development Tracker</a></h2>
         </div>
       </div>
     </header>
-    <div id="feedback-banner">
-      <div class="row">
-         <div class="twelve columns">
-            <p>This is a Beta test site and we encourage your <a href="/feedback">feedback</a> on the site.</p>
-          </div>
-      </div>
-    </div>
 
     <div class="page-wrapper">
-    
-    
-    
                 <%= yield %>
     </div><!-- end page-wrapper -->  
 
@@ -74,7 +64,7 @@
           </nav>
           <div class="row">
             <div class="twelve columns">
-              <p>Much of the information on this website is available for reuse under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/" rel="license">Open Government Licence</a></p>
+              <p>The information on this website is available for reuse under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/" rel="license">Open Government Licence</a></p>
             </div>
           </div>
         </div>

--- a/src/platform/site/source/layouts/layout.erb
+++ b/src/platform/site/source/layouts/layout.erb
@@ -45,7 +45,7 @@
     <header role="banner" id="global-header">
       <div class="row">
         <div class="twelve columns">
-          <h2><a href="/" title="Go to the homepage">Development Tracker <span style="color: #F17921">Beta</span></a></h2>
+          <h2><a href="/" title="Go to the homepage">Development Tracker</a></h2>
           <form id="search" class="site-search" action="/search" method="GET" role="search">
             <label for="site-search-text" class="visually-hidden">Search</label>
             <input type="search" name="query" id="site-search-text" title="Search"><input class="button" type="submit" value="Search">
@@ -53,17 +53,7 @@
         </div>
       </div>
     </header>
-    <div id="feedback-banner">
-      <div class="row">
-         <div class="twelve columns">
-            <p>This is a Beta test site and we encourage your <a href="/feedback">feedback</a> on the site.</p>
-          </div>
-      </div>
-    </div>
     <div class="page-wrapper">
-    
-    
-    
                 <%= yield %>
     </div><!-- end page-wrapper -->  
     
@@ -81,7 +71,7 @@
           </nav>
           <div class="row">
             <div class="twelve columns">
-              <p>Much of the information on this website is available for reuse under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/" rel="license">Open Government Licence</a></p>
+              <p>The information on this website is available for reuse under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/" rel="license">Open Government Licence</a></p>
           </div>
           </div>
         </div>


### PR DESCRIPTION
This change removes all references to the Beta, including:
- title
- top of page Beta banner
- About page

Once this PR has been merged, the changes will be picked up on the next Deploy.
