### PR TITLE
Update to Partner Projects - 

### DIFF
--- a/src/platform/site/config.rb
+++ b/src/platform/site/config.rb
@@ -215,7 +215,8 @@ end
     'start-actual'      => funded_project['start-actual'],
     'start-planned'     => funded_project['start-planned'],
     'status'            => funded_project['status'],
-    'organisation'      => funded_project['organisation']
+    'organisation'      => funded_project['organisation'],
+    'recipient'         => funded_project['recipient']
   }
 
   # get the other funded projects


### PR DESCRIPTION
Include recipient country/region in Partner Projects data object so that they display a map when rendered on the projects page - V2 required due to GIT issues with update one.

The following updates were made as part of this update change:

ProjectAggregator.scala - Update the cypher collectPartnerProjects so that the recipient country/region value is taken from the neo4J database and inserted into Mongo for Partner Projects.

Config.rb - add recipient to the list of attributes for each funded project that is identified in the database -@cms_db['funded-projects'].find({}).to_a.each do |funded_project|

QA the project page using the following partner projects to test the changes that have been made to the code:

Test - Partner projects that have recipient countries assigned to them - GB-CHC-1064413-GPAF-INN-001-DIFD2, GB-CHC-1099776-J7PPA & GB-CHC-1068839-dfid_ag_11-13
Result - All of the projects were rendered correctly with an appropriate map.

Test - A partner project that has no recipient country/region assigned to it - GB-CHC-326568-SR12UKAidMatch.
Result - The page displays without a map - this is the expected behaviour.
