### PR TITLE
240 search index plan

### DIFF
--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Indexer.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/Indexer.scala
@@ -50,9 +50,10 @@ class Indexer @Inject()(db: DefaultDB, engine: ExecutionEngine, sectors: Sectors
         |        component-[?:sector]-sector,
         |        component-[?:`recipient-region`]-region,
         |        component-[?:`recipient-country`]-country,
-        |        component-[:`participating-org`]-org,
+        |        rorg-[:`reporting-org`]-component-[:`participating-org`]-org,
         |        component-[?:`iati-identifier`]-id
-        | WHERE  project.type = 1
+        | WHERE  rorg.ref = "GB-1"
+        |        AND project.type = 1
         | RETURN COLLECT(DISTINCT(COALESCE(component.`iati-identifier`?, id.`iati-identifier`?))) as ids,
         |        project.ref                                    as parent,
         |        COLLECT(DISTINCT(sector.code))                 as sectors,


### PR DESCRIPTION
This change fixes indexing issue during data load. Currently data loading breaks if some funded files are included. For details please follow: https://trello.com/c/1sOqde6H/240-10-plan-uk-file-breaks-the-indexer-and-search
