### PR TITLE
updated leaflet maps to point to tilestream on devtracker.dfid.gov.uk

### DIFF
--- a/src/platform/site/source/javascripts/leaflet/indexmap.js
+++ b/src/platform/site/source/javascripts/leaflet/indexmap.js
@@ -163,7 +163,7 @@
 
     // map.addLayer(new L.Google('ROADMAP'))
     // creates a tile layer with the tiles hosted in mapbox
-    L.tileLayer("http://aipalpha.dfid.gov.uk/v2/dfid/{z}/{x}/{y}.png", {
+    L.tileLayer("http://devtracker.dfid.gov.uk/v2/dfid-towns/{z}/{x}/{y}.png", {
                             minZoom: 2,
                             maxZoom: 4,
                             attribution: ''

--- a/src/platform/site/source/javascripts/leaflet/mapclustering.js
+++ b/src/platform/site/source/javascripts/leaflet/mapclustering.js
@@ -29,7 +29,7 @@ function createMapWithCoordinates(coordinatesArray){
         var map = L.map('map');
 
         // creates a tile layer
-        L.tileLayer("http://aipalpha.dfid.gov.uk/v2/dfid-towns/{z}/{x}/{y}.png", {
+        L.tileLayer("http://devtracker.dfid.gov.uk/v2/dfid-towns/{z}/{x}/{y}.png", {
             minZoom: 1,
             maxZoom: 10,
             attribution: ''


### PR DESCRIPTION
Tested on dev box to show that the devtracker.dfid.gov.uk/location map is showing correctly. Will need a Deploy to ensure the javascript assets are copied to the right directory.
