### PR TITLE
Data load for partner org rework#t239

### DIFF
--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/ProjectAggregator.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/ProjectAggregator.scala
@@ -285,6 +285,7 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
         val funds       = row("funds") match {
           case v: java.lang.Integer => v.toLong
           case v: java.lang.Long    => v.toLong
+          case v: java.lang.Double  => v.toLong
           case v: java.lang.String => try { v.toLong } catch { case _ : Throwable => 0 }
           case _ => 0
         }
@@ -325,6 +326,7 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
           """.stripMargin).toSeq.head("totalBudget") match {
           case v: java.lang.Integer => v.toLong
           case v: java.lang.Long    => v.toLong
+          case v: java.lang.Double    => v.toLong
           case v: java.lang.String => try { v.toLong } catch { case _ : Throwable => 0 }
           case _ => 0
         }
@@ -340,6 +342,7 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
           """.stripMargin).toSeq.head("totalSpend") match {
           case v: java.lang.Integer => v.toLong
           case v: java.lang.Long    => v.toLong
+          case v: java.lang.Double    => v.toLong
           case v: java.lang.String => try { v.toLong } catch { case _ : Throwable => 0 }
           case _ => 0
         }


### PR DESCRIPTION
Work done in this branch is primarily to fix issues when loading partner files. It has been noticed that data in many partner files are not in the format (or in type) as expected in dev tracker. Therefore on many cases data casting (from neo4j to mongo using cypher queries) throws exception and the data loading breaks.

Here data type has been checked before casting or converting to different data type. Probably not the best way to handle this issue (could have a dedicated function to handle this type conversion), however it works. Going forward we may need think how to provide default data value when data is invalid format or type mismatches.

Associated trello card for this branch is card # 239. All findings have been documented on that card.
