### PR TITLE
Changes have been made to allow ref value (participating-org and reporti...

### DIFF
--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/util/SupportedOrgRefsForPartners.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/util/SupportedOrgRefsForPartners.scala
@@ -1,0 +1,21 @@
+package uk.gov.dfid.loader.util
+
+object SupportedOrgRefsForPartners {
+
+	val Participating = Seq(
+    "GB",                   
+    "GB-1"
+  )
+
+	val Reporting = Seq(
+    "GB",                   
+    "GB-1"
+  )
+
+	val Provider = Seq(
+    "GB",                   
+    "GB-1"
+  )
+
+
+}


### PR DESCRIPTION
Changes have been made to allow ref value (participating-org and reporting-org) 'GB' along with 'GB-1' when loading partner projects. The change has only been applied to load partner projects. Sequence of allowable ref values have been listed for participating-org, reporting-org and partner-org in an utility object and when loading partner projects, the sequences are supplying ref values in an IN query. Currently only paricipating-org and reporting-org sequences are being used.
