### PR TITLE
Partners of partner

### DIFF
--- a/src/platform/site/config.rb
+++ b/src/platform/site/config.rb
@@ -166,7 +166,7 @@ CodeLists.all_global_recipients.map { |code, name|
   end
 
   if has_funded_projects then
-    proxy "/projects/#{id}/partners/index.html",   '/projects/partners.html',     :locals => { :project => project, :funded_projects => funded_projects }
+    proxy "/projects/#{id}/partners/index.html",   '/projects/partners.html',     :locals => { :project => project, :funded_projects => funded_projects, :is_funded_by_dfid_project => true }
   end
 end
 
@@ -230,9 +230,9 @@ end
 
   # get the other funded projects
   funded_projects = @cms_db['funded-projects'].find({ 
-    'funding' => funded_project['funding'],
-    'funded'  => { '$ne' => funded_project['funded'] } 
+    'funding' => funded_project['funded']
   }).to_a
+  has_funded_projects = funded_projects.size > 0
 
   # get the parent project
   funding_project    = @cms_db['projects'].find_one({ 'iatiId' =>  funded_project['funding'] })
@@ -263,7 +263,14 @@ end
   proxy "/projects/#{project['iatiId']}/index.html",              '/projects/summary.html',      :locals => { :project => project, :has_funded_projects => true, :non_dfid_data => true, :locations => [] }
   proxy "/projects/#{project['iatiId']}/documents/index.html",    '/projects/documents.html',    :locals => { :project => project, :has_funded_projects => true, :non_dfid_data => true, :documents => documents  }
   proxy "/projects/#{project['iatiId']}/transactions/index.html", '/projects/transactions.html', :locals => { :project => project, :has_funded_projects => true, :non_dfid_data => true, :transaction_groups => transaction_groups  }
-  proxy "/projects/#{project['iatiId']}/partners/index.html",     '/projects/partners.html',     :locals => { :project => project, :has_funded_projects => true, :non_dfid_data => true, :funded_projects => funded_projects, :funding_project => funding_project  }
+  
+  is_funded_by_dfid_project = true
+  if funding_project.nil? then
+    funding_project    = @cms_db['funded-projects'].find_one({ 'funded' =>  funded_project['funding'] })
+    is_funded_by_dfid_project = false
+  end
+
+  proxy "/projects/#{project['iatiId']}/partners/index.html",     '/projects/partners.html',     :locals => { :project => project, :has_funded_projects => has_funded_projects, :non_dfid_data => true, :funded_projects => funded_projects, :funding_project => funding_project, :is_funded_by_dfid_project => is_funded_by_dfid_project }
   
 end
 

--- a/src/platform/site/source/projects/partners.html.erb
+++ b/src/platform/site/source/projects/partners.html.erb
@@ -8,26 +8,37 @@ title: Development Tracker
       <div class="twelve columns results-info">
         <h3 class="section-group-title">Funding Project</h3>
         <div class="row">
-            <div class="four columns summary">
-                <h4>DFID</h4>     
-            </div>
-            <div class="eight columns">
-                <ul>
-                    <li><a href="/projects/<%=funding_project['iatiId']%>"><%=funding_project['title']%></a><%=funding_project['description']%><span><%= number_to_currency(project['funds'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) %></span></li>
-                </ul> 
-            </div>
+            <% if is_funded_by_dfid_project then %>
+              <div class="four columns summary">
+                  <h4>DFID</h4>     
+              </div>
+              <div class="eight columns">
+                  <ul>
+                      <li><a href="/projects/<%=funding_project['iatiId']%>"><%=funding_project['title']%></a><%=funding_project['description']%><span><%= number_to_currency(project['funds'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) %></span></li>
+                  </ul> 
+              </div>
+            <% else %>
+              <div class="four columns summary">
+                  <h4><%=funding_project['reporting']%></h4>         
+              </div>
+              <div class="eight columns">
+                  <ul>
+                      <li><a href="/projects/<%=funding_project['funded']%>"><%=funding_project['title']%></a><%=funding_project['description']%><span><%= number_to_currency(project['funds'], :unit=>currency_symbol(project['currency']) || "£", :precision => 0) %></span></li>
+                  </ul> 
+              </div>
+           <% end %>
         </div>
       </div>
   </div>
-<% else %>
-
+<% end %>
+<% if funded_projects.count > 0 then %> 
   <div class="row">
-      <div class="twelve columns results-info">
-
-        <% if funded_projects.count > 0 then %>
+      <div class="twelve columns results-info">                 
+        <% if is_dfid_project(project['iatiId']) then %>
           <h3 class="section-group-title">Partner Projects</h3>
-        <% end %>
-
+        <%else%>
+          <h3 class="section-group-title">Funded Projects</h3>
+        <%end%>
         <% funded_projects.each do |funded_project| %>
           <div class="row">
               <div class="four columns summary">


### PR DESCRIPTION
Considering the fact that a partner project, gets fund from some DFID project, may also fund some other projects, this change shows all funded projects as well as the funding project under partner tab. Currently for DFID projects we list all partner projects, and no change has been made. However when some partner project funded by some other partner project, hitting the partner link throws a 404 error and this has now been fixed. So if a partner project gets fund directly from some DFID project and in turn funds other projects, the information has been captured under "Funding" and "Funded" labels in partner tab. 

The related trello card is: https://trello.com/c/Em5vPghP/330-partners-of-partner-projects
