### PR TITLE
Modified R4D url to point to the new location for the R4D service.

### DIFF
--- a/src/platform/site/helpers/document_helpers.rb
+++ b/src/platform/site/helpers/document_helpers.rb
@@ -6,7 +6,8 @@ require "uri"
 def r4DApiDocFetch(projectId)
 	
 	begin
-		uri_str = URI.escape("http://linked-development.org/openapi/r4d/get/research_outputs/"+projectId+"?per_project=5&format=json")
+		uri_str = URI.escape("http://api.linkeddev.swirrl.com/openapi/r4d/get/research_outputs/"+projectId+".json?per_project=5")
+		
 		uri = URI.parse(uri_str)
  
 		http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
The api for R4D has been changed. It used to be "http://linked-development.org", and new api is "http://api.linkeddev.swirrl.com/". This is a simple change to replace the previous api to show the research documents, if any, for a project.

The trello card for this change is: https://trello.com/c/140QAJjZ/308-8-modify-r4d-to-point-to-the-new-location-for-the-r4d-service
