### PR TITLE
Exception in search functionality

### DIFF
--- a/src/platform/modules/search/app/controllers/Application.scala
+++ b/src/platform/modules/search/app/controllers/Application.scala
@@ -14,8 +14,7 @@ object Application extends Controller {
         val (projects, countries) = ElasticSearch.search(query).partition(_.contains("id"))
         if(countries.isEmpty) {
           Ok(views.html.search(query, projects.size , projects, countries))
-        } else {
-          val country = countries.maxBy(_("countryBudget").asInstanceOf[Double])
+        } else {          
           Ok(views.html.search(query, projects.size , projects, countries))
         }
       }


### PR DESCRIPTION
Changed casting from Int to Double for country budget when country with 'max country budget' was searched, although I haven't found any use of the resultant country.
