### PR TITLE
Country description text slicing

### DIFF
--- a/src/platform/site/source/countries/country.html.erb
+++ b/src/platform/site/source/countries/country.html.erb
@@ -28,7 +28,7 @@ title: Development Tracker
         <div class="description"><%= markdown_to_html(h country['description'])%></div>
         <script type="text/javascript">
             $('div.description').expander({
-                slicePoint    : 300,
+                slicePoint    : <%= country['description'].index('<!--(more)-->') || 300 %>,
                 expandSpeed   : 0,
                 collapseSpeed : 0,
                 expandText    : 'Read more about <%=h country["name"] %>' 


### PR DESCRIPTION
Changed logic to slice the text for country description. Country description text will be sliced upto (where the text) '<--(more)-->' is found, otherwise will take 300 words (which was done previously). This would give more control on slicing country description text. To see this in action, we need to update the country description text  (inserting the '<--(more)-->' flag) using the CMS. Also worth to note that, the '<--(more)-->' flag will now be part of country description, though will not be displayed in HTML pages.
