### PR TITLE
Other org aggregator decimal fix

### DIFF
--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/OtherOrgAggregator.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/OtherOrgAggregator.scala
@@ -244,16 +244,10 @@ class OtherOrgAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLo
       //auditor.info(s"$project")
 
       if(project!=""){
- //       val value = Converter.toDouble(row("value"))
-        val value       = row("valueReturn") match {            
-            case v: java.lang.Long    =>  Converter.toDouble(v) // v.toLong
-            case v: java.lang.Double  =>  Converter.toDouble(v) //v.toLong
-            case v: java.lang.String => try {Converter.toDouble(v)} catch { case _ : Throwable => 0 }
-            case _ => 0
-          }
-        val date        = try { DateTime.parse(row("dateReturn").asInstanceOf[String], format).getMillis } catch { case _ : Throwable => 0 }
-        val transaction = row("typeReturn").asInstanceOf[String]
-        val description = row("description").asInstanceOf[String]
+          val value       = Converter.toDouble(row("valueReturn"))
+          val date        = try { DateTime.parse(row("dateReturn").asInstanceOf[String], format).getMillis } catch { case _ : Throwable => 0 }
+          val transaction = row("typeReturn").asInstanceOf[String]
+          val description = Converter.toString(row("description"))
 
         //auditor.info(s"transactions insert: $project, $description, $date, $transaction")
 
@@ -262,7 +256,6 @@ class OtherOrgAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLo
             "project"     -> BSONString(project),
             "description" -> BSONString(description),
             "component"   -> BSONString(""),
-         // "value"       -> BSONLong(value),
             "value"       -> BSONDouble(value), 
             "date"        -> BSONDateTime(date),
             "type"        -> BSONString(transaction)

--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/util/Converter.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/util/Converter.scala
@@ -21,4 +21,16 @@ object Converter {
             case _ => 0
         }
 	}
+
+    def toString(input: Any) : String = {
+
+        input match {
+            case v: java.lang.String => v.toString
+            case v: java.lang.Long    => try { v.toString} catch { case _ : Throwable => "" }
+            case v: java.lang.Double    => try { v.toString } catch { case _ : Throwable => "" }
+            case _ => ""
+        }
+    }
+
+
 }


### PR DESCRIPTION
The fix was put in place to allow the DEFRA file to be loaded into DevTracker as it had Decimal values in its transactions and the transaction description was set to '2012' which was causing a casting error.
