### PR TITLE
#209 partner file data load issue

### DIFF
--- a/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/ProjectAggregator.scala
+++ b/src/platform/modules/loader/src/main/scala/uk/gov/dfid/loader/ProjectAggregator.scala
@@ -317,11 +317,7 @@ class ProjectAggregator(engine: ExecutionEngine, db: DefaultDB, auditor: DataLoa
 
           if( dateType != "")
           {
-            //Newly added
             val date     = DateTime.parse(row("date").asInstanceOf[String].replace('Z',' ').trim(),format)
-            //date         = date.trim()
-            //date         = DateTime.parse(date, format)
-            //val date     = DateTime.parse(row("date").asInstanceOf[String], format)
             dateType -> BSONDateTime(date.getMillis)
           }
           else


### PR DESCRIPTION
suffix Z in All date element in Malaria Consortium Activity files are handled properly by replaceing with whitespace and trimimg the whitespace to get standard date format (yyyy-MM-dd) and data load process works for all partner files
