### PR TITLE
Comment out the smtp mock attribute as it was causing the emails to fail

### DIFF
--- a/src/platform/conf/application.conf
+++ b/src/platform/conf/application.conf
@@ -39,7 +39,7 @@ deployment.password=${?DFID_DEPLOYMENT_PASSWORD}
 #address.feedback="devtracker-feedback@dfid.gov.uk"
 
 #This value is used to allow testing on the development machines
-smtp.mock=true
+#smtp.mock=true
 
 # This is not required as we are relaying through a local Postfix server rather than direct to SES
 #smtp.host="email-smtp.us-east-1.amazonaws.com"


### PR DESCRIPTION
This value has been causing issues with the email server since it was checked into the code, so it has been commented out.
